### PR TITLE
Use Pascal RANDOM and not MTH$RANDOM.

### DIFF
--- a/env/rtldef.pas
+++ b/env/rtldef.pas
@@ -3,9 +3,11 @@
 const	lib$m_cli_ctrlt = %x00100000;
 	lib$m_cli_ctrly = %x02000000;
 
+(* Incompatible with IEEE FP; use Pascal RANDOM instead
 [asynchronous, external(mth$random)] function $random(
 	var seed : unsigned) : real;
 	extern;
+*)
 
 [asynchronous, external(lib$day_of_week)] function $day_of_week(
 	var time : $uquad := %immed 0;

--- a/zk/zkroutines.pas
+++ b/zk/zkroutines.pas
@@ -31,7 +31,7 @@ end;
 	var seed : unsigned;
 	upper : integer) : integer;
 begin
-	zk$random_integer:=trunc($random(seed)*upper)+1;
+	zk$random_integer:=trunc(RANDOM*upper)+1;
 end;
 
 [global] function zk$compare_date(


### PR DESCRIPTION
The no-longer-documented MTH$RANDOM returns its result in VAX FP format. The game gives array index exceptions because it's expecting IEEE values (on non-VAX).

Changed to use Pascal's RANDOM function, which returns the same range.